### PR TITLE
New parameters for better customization

### DIFF
--- a/MarkdownToHtml.psm1
+++ b/MarkdownToHtml.psm1
@@ -1328,7 +1328,7 @@ function ConvertTo-NavigationItem {
 }
 
 # find headings h2 .. h6 on in an HTML fragment.
-$SCRIPT:hRE = New-Object regex '<h([2-6])[^<>]* id="([^"])+"[^<]*>(.+?)\s*(?=<\/h.*|$)'
+$SCRIPT:hRE = New-Object regex '<h([2-6])[^<>]* id="([^"])+"[^<]*>(.+?)\s*(?=<\/h\d.*|$)'
 # Match a hyperlink
 $aRE = New-Object regex '</{0,1} *a[^>]*>'
 


### PR DESCRIPTION
Parameters were added to better customize the heading and the site_navigation.

The ConvertTo-NavigationItem and ConvertTo-PageHeadingNavigation functions were modified in the latter, the identification regex was modified so that it only matched the heading of h2 .. h6. The h1 is almost always used for the title of the markdown document and it is not justified to add it to the PageHeadingNavigation. 